### PR TITLE
Switches to the k8s project's echoserver

### DIFF
--- a/service-from-image/echo.yaml
+++ b/service-from-image/echo.yaml
@@ -9,7 +9,7 @@ spec:
       revisionTemplate:
         spec:
           container:
-            image: solsson/http-echo@sha256:cadde771b6e022c3ea1a8ee84958d9b82ba5f7bda5f75730a8f8542d206c321c
+            image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
             env:
             - name: PORT
               value: "8080"


### PR DESCRIPTION
which displays some pod info as well
and has a more human friendly output format